### PR TITLE
fix bug : the font selected of mSpinBox object is not effective on runt time.

### DIFF
--- a/src/mresmanager.c
+++ b/src/mresmanager.c
@@ -1248,7 +1248,10 @@ int ncsCreateModalDialogFromID (HPACKAGE package, Uint32 dlgId,
 
     if (dialog) {
         ret = _c(dialog)->doModal(dialog, TRUE);
-        MainWindowThreadCleanup(dialog->hwnd);
+        if(IsMainWindow(dialog->hwnd))
+        {
+        	MainWindowThreadCleanup(dialog->hwnd);
+        }
     }
 
     return ret;

--- a/src/mspinbox.c
+++ b/src/mspinbox.c
@@ -437,24 +437,9 @@ static BOOL mSpinBox_onCreate(mSpinBox *self, LPARAM lParam)
 	return FALSE;
 }
 
-static inline BOOL is_system_font(PLOGFONT logfont)
-{
-    if(logfont){
-        for(int font_id = 0; font_id < NR_SYSLOGFONTS; ++font_id)
-        {
-            if(logfont == g_SysLogFont[font_id])
-            {
-                return TRUE;
-            }
-
-        }
-    }
-    return FALSE;
-}
-
 static LRESULT mSpinBox_wndProc (mSpinBox* self, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    PLOGFONT self_font,editor_font,old_font;
+    PLOGFONT self_font;
     switch(message) {
         case MSG_SETFOCUS:
         {
@@ -471,15 +456,7 @@ static LRESULT mSpinBox_wndProc (mSpinBox* self, UINT message, WPARAM wParam, LP
         {
             /* set editor's font with mSpinBox object's font */
             self_font = GetWindowFont(self->hwnd);
-            editor_font = is_system_font(self_font)
-                    ? self_font
-                    : CreateLogFontIndirect(self_font);
-            old_font = SetWindowFont (GetDlgItem(self->hwnd, EDITOR_CHILD_ID), editor_font);
-            /* can't destroy system font */
-            if (!is_system_font(old_font))
-            {
-                DestroyLogFont(old_font);
-            }
+            SetWindowFont (GetDlgItem(self->hwnd, EDITOR_CHILD_ID), self_font);
             break;
         }
 		default:


### PR DESCRIPTION
Bug descriptsion:
the font selected by `mSpinBox `object is not effective on runt time.

REASON:
`mSpinBox_wndProc `function don't respond message `MSG_FONTCHANGED`,

SOLUTION:

moditiy the `mSpinBox_wndProc `,add respone of `MSG_FONTCHANGED` , set font of child editor.

fixed another issue: 
replace all of hardcode `100`  that  represent for editor id with a new preprocessor `EDITOR_CHILD_ID`

